### PR TITLE
reference resources in serverless.yml for the table name

### DIFF
--- a/04-rest-vanilla/serverless.yml
+++ b/04-rest-vanilla/serverless.yml
@@ -14,8 +14,7 @@ provider:
   iamRoleStatements: ${file(resources/iamRoleStatement.yml)}
   environment:
     NODE_ENV: ${self:provider.stage}
-    TABLE_FOODS:
-      Ref: TableFoods
+    TABLE_FOODS: ${self:resources.Resources.TableFoods.Properties.TableName}
 
 custom:
   DEFAULT_STAGE: local

--- a/04-rest-vanilla/src/config/index.js
+++ b/04-rest-vanilla/src/config/index.js
@@ -1,12 +1,9 @@
-// Workaround for serverless offline config support. (MR's welcome here...)
-Object.keys(process.env).forEach(key => { if (process.env[key] === '[object Object]') process.env[key] = '' });
-
 module.exports = {
   ENV: process.env.NODE_ENV,
   LOCAL_ENV: 'local',
   AWS_DEFAULT_REGION: 'us-east-1',
   AWS_PROFILE: 'myawsprofile',
   TABLES: {
-    FOOD: process.env.TABLE_FOODS || 'restvanilla-dev-table-foods',
+    FOOD: process.env.TABLE_FOODS,
   }
 }


### PR DESCRIPTION
Hi, I think this will solve the issue of getting the table name in the variable environment so you don't need to hardcode the TableName in the config file, I'm working on something similar with serverless-offline right now and it works for me.

BTW let me know if it works for you